### PR TITLE
Support override configs for buffer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Build/coverage_linux
 /cmake-build-debug-visual-studio
 /cmake-build-release-visual-studio
 /Build
+
+tests/data/override/*.cfg

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Tests
+
+To run integration tests with large media files, place the following files in `tests/data/override/` or specify their locations via environment variables:
+
+- `input.yuv` (`BUFFER_TEST_INPUT_YUV`)
+- `stream.jxs` (`BUFFER_TEST_STREAM_JXS`)
+- `enc.cfg` (`BUFFER_TEST_ENC_CFG`)
+- `dec.cfg` (`BUFFER_TEST_DEC_CFG`)
+
+When overriding `input.yuv` or `stream.jxs`, the corresponding `enc.cfg` or `dec.cfg` must reside in the same directory.

--- a/tests/integration/BufferAppTests.cpp
+++ b/tests/integration/BufferAppTests.cpp
@@ -32,8 +32,12 @@ fs::path find_override(const char *env_var, const std::string &name) {
 
 std::string read_cfg(const fs::path &path) {
     std::ifstream ifs(path);
-    std::string content;
-    std::getline(ifs, content);
+    std::string content((std::istreambuf_iterator<char>(ifs)), {});
+    for (char &c : content) {
+        if (c == '\n' || c == '\r') {
+            c = ' ';
+        }
+    }
     return content;
 }
 

--- a/tests/integration/BufferAppTests.cpp
+++ b/tests/integration/BufferAppTests.cpp
@@ -19,6 +19,17 @@ fs::path data_dir() {
     return fs::path(TEST_DATA_DIR);
 }
 
+fs::path find_override(const char *env_var, const std::string &name) {
+    if (const char *env = std::getenv(env_var); env && fs::exists(env)) {
+        return fs::path(env);
+    }
+    fs::path override = data_dir() / "override" / name;
+    if (fs::exists(override)) {
+        return override;
+    }
+    return {};
+}
+
 std::string read_cfg(const fs::path &path) {
     std::ifstream ifs(path);
     std::string content;
@@ -49,34 +60,88 @@ int run_cmd(const std::string &cmd) {
 TEST(BufferApps, EncodeMatch) {
     fs::path tmp = fs::temp_directory_path() / "buffer_encode_test";
     fs::create_directories(tmp);
-    fs::path input = tmp / "input.yuv";
+    fs::path input_override = find_override("BUFFER_TEST_INPUT_YUV", "input.yuv");
+    fs::path input = input_override.empty() ? tmp / "input.yuv" : input_override;
+    if (input_override.empty()) {
+        write_yuv(input);
+    }
     fs::path out1 = tmp / "enc.jxs";
     fs::path out2 = tmp / "enc_buf.jxs";
-    write_yuv(input);
-    std::string cfg_args = read_cfg(data_dir() / "enc.cfg");
+
+    fs::path enc_cfg_override = find_override("BUFFER_TEST_ENC_CFG", "enc.cfg");
+    fs::path enc_cfg_path;
+    if (!input_override.empty()) {
+        if (!enc_cfg_override.empty()) {
+            enc_cfg_path = enc_cfg_override;
+        } else {
+            enc_cfg_path = input.parent_path() / "enc.cfg";
+            ASSERT_TRUE(fs::exists(enc_cfg_path)) << "enc.cfg not found alongside overridden input";
+        }
+    } else {
+        enc_cfg_path = !enc_cfg_override.empty() ? enc_cfg_override : data_dir() / "enc.cfg";
+    }
+    std::string cfg_args = read_cfg(enc_cfg_path);
     fs::path enc_app = fs::path(".") / "SvtJpegxsEncApp";
     fs::path enc_app_buf = fs::path(".") / "EncAppBuffer";
-    ASSERT_EQ(0, run_cmd(enc_app.string() + " " + cfg_args + " -i \"" + input.string() + "\" -b \"" + out1.string() + "\""));
-    ASSERT_EQ(0, run_cmd(enc_app_buf.string() + " " + cfg_args + " -i \"" + input.string() + "\" -b \"" + out2.string() + "\""));
+    std::string cmd1 = enc_app.string() + " " + cfg_args + " -i \"" + input.string() + "\" -b \"" + out1.string() + "\"";
+    ASSERT_EQ(0, run_cmd(cmd1));
+    std::string cmd2 = enc_app_buf.string() + " " + cfg_args + " -i \"" + input.string() + "\" -b \"" + out2.string() + "\"";
+    ASSERT_EQ(0, run_cmd(cmd2));
     EXPECT_TRUE(files_equal(out1, out2));
 }
 
 TEST(BufferApps, DecodeMatch) {
     fs::path tmp = fs::temp_directory_path() / "buffer_decode_test";
     fs::create_directories(tmp);
-    fs::path input = tmp / "input.yuv";
-    fs::path bitstream = tmp / "stream.jxs";
+    fs::path stream_override = find_override("BUFFER_TEST_STREAM_JXS", "stream.jxs");
+    bool use_stream_override = !stream_override.empty();
+    fs::path bitstream = use_stream_override ? stream_override : tmp / "stream.jxs";
+
+    if (!use_stream_override) {
+        fs::path input_override = find_override("BUFFER_TEST_INPUT_YUV", "input.yuv");
+        fs::path input = input_override.empty() ? tmp / "input.yuv" : input_override;
+        if (input_override.empty()) {
+            write_yuv(input);
+        }
+        fs::path enc_cfg_override = find_override("BUFFER_TEST_ENC_CFG", "enc.cfg");
+        fs::path enc_cfg_path;
+        if (!input_override.empty()) {
+            if (!enc_cfg_override.empty()) {
+                enc_cfg_path = enc_cfg_override;
+            } else {
+                enc_cfg_path = input.parent_path() / "enc.cfg";
+                ASSERT_TRUE(fs::exists(enc_cfg_path)) << "enc.cfg not found alongside overridden input";
+            }
+        } else {
+            enc_cfg_path = !enc_cfg_override.empty() ? enc_cfg_override : data_dir() / "enc.cfg";
+        }
+        std::string enc_cfg = read_cfg(enc_cfg_path);
+        fs::path enc_app = fs::path(".") / "SvtJpegxsEncApp";
+        std::string enc_cmd = enc_app.string() + " " + enc_cfg + " -i \"" + input.string() + "\" -b \"" + bitstream.string() + "\"";
+        ASSERT_EQ(0, run_cmd(enc_cmd));
+    }
+
     fs::path out1 = tmp / "dec.yuv";
     fs::path out2 = tmp / "dec_buf.yuv";
-    write_yuv(input);
-    std::string enc_cfg = read_cfg(data_dir() / "enc.cfg");
-    fs::path enc_app = fs::path(".") / "SvtJpegxsEncApp";
+    fs::path dec_cfg_override = find_override("BUFFER_TEST_DEC_CFG", "dec.cfg");
+    fs::path dec_cfg_path;
+    if (use_stream_override) {
+        if (!dec_cfg_override.empty()) {
+            dec_cfg_path = dec_cfg_override;
+        } else {
+            dec_cfg_path = bitstream.parent_path() / "dec.cfg";
+            ASSERT_TRUE(fs::exists(dec_cfg_path)) << "dec.cfg not found alongside overridden stream";
+        }
+    } else {
+        dec_cfg_path = !dec_cfg_override.empty() ? dec_cfg_override : data_dir() / "dec.cfg";
+    }
+    std::string dec_cfg = read_cfg(dec_cfg_path);
     fs::path dec_app = fs::path(".") / "SvtJpegxsDecApp";
     fs::path dec_app_buf = fs::path(".") / "DecAppBuffer";
-    ASSERT_EQ(0, run_cmd(enc_app.string() + " " + enc_cfg + " -i \"" + input.string() + "\" -b \"" + bitstream.string() + "\""));
-    std::string dec_cfg = read_cfg(data_dir() / "dec.cfg");
-    ASSERT_EQ(0, run_cmd(dec_app.string() + " " + dec_cfg + " -i \"" + bitstream.string() + "\" -o \"" + out1.string() + "\""));
-    ASSERT_EQ(0, run_cmd(dec_app_buf.string() + " " + dec_cfg + " -i \"" + bitstream.string() + "\" -o \"" + out2.string() + "\""));
+    std::string dec_cmd1 = dec_app.string() + " " + dec_cfg + " -i \"" + bitstream.string() + "\" -o \"" + out1.string() + "\"";
+    ASSERT_EQ(0, run_cmd(dec_cmd1));
+    std::string dec_cmd2 = dec_app_buf.string() + " " + dec_cfg + " -i \"" + bitstream.string() + "\" -o \"" + out2.string() + "\"";
+    ASSERT_EQ(0, run_cmd(dec_cmd2));
     EXPECT_TRUE(files_equal(out1, out2));
 }
 


### PR DESCRIPTION
## Summary
- allow buffer app integration tests to use alternative input, stream and cfg files via environment variables or `tests/data/override`
- ensure overridden streams and inputs have matching `enc.cfg`/`dec.cfg`
- document override usage and ignore local cfg overrides

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build --target BufferAppTests`
- `ctest -R buffer_apps --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bd224292708324b89348763df2b747